### PR TITLE
Fix UNDO message; fix recipe file growth

### DIFF
--- a/src/main/java/net/doubledoordev/craycrafting/recipes/BaseType.java
+++ b/src/main/java/net/doubledoordev/craycrafting/recipes/BaseType.java
@@ -159,7 +159,7 @@ public abstract class BaseType<T extends IRecipe>
     {
         if (applied)
         {
-            CrayCrafting.instance.logger.info("UNDO " + getTypeName() + "\t Removed " + removedList.size() + "\t & added " + addedList.size() + "\t recipes from " + FMLCommonHandler.instance().getEffectiveSide());
+            CrayCrafting.instance.logger.info("UNDO " + getTypeName() + "\t Removed " + addedList.size() + "\t & added " + removedList.size() + "\t recipes from " + FMLCommonHandler.instance().getEffectiveSide());
             applied = false;
             CraftingManager.getInstance().getRecipeList().removeAll(addedList);
             CraftingManager.getInstance().getRecipeList().addAll(removedList);
@@ -176,6 +176,16 @@ public abstract class BaseType<T extends IRecipe>
     {
         return nbtList;
     }
+	
+	/**
+	 * Used to clear existing randomized recipes in nbt file data, before adding the new ones.
+     * <p/>
+	 * Used on server only.
+	 */
+	public void resetNBTList()
+	{
+		nbtList = new NBTTagList();
+	}
 
     /**
      * Used on server only.

--- a/src/main/java/net/doubledoordev/craycrafting/recipes/RecipeRegistry.java
+++ b/src/main/java/net/doubledoordev/craycrafting/recipes/RecipeRegistry.java
@@ -147,6 +147,11 @@ public class RecipeRegistry
         ArrayList<ItemStack> outputs = new ArrayList<ItemStack>(CraftingManager.getInstance().getRecipeList().size());
         ArrayList<IRecipe> acceptedRecipes = new ArrayList<IRecipe>();
 
+		for (BaseType<IRecipe> baseType : typeList)
+		{
+			baseType.resetNBTList();
+		}
+		
         for (IRecipe recipe : (List<IRecipe>) CraftingManager.getInstance().getRecipeList())
         {
             for (BaseType<IRecipe> baseType : typeList)


### PR DESCRIPTION
- Fixed the minor debug message typo for "UNDO [BaseType] Removed x
  Added y" having the Removed/Added counts backwards.
- Added code to reset the nbtList between each randomization to prevent
  exponential recipe bloat in craycrafting.dat
  This should correct issue #4 that I opened.  I have built an updated .jar and tested and it works correctly.
